### PR TITLE
Add SwiftUI client skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ sudo systemctl enable nginx
 sudo systemctl start nginx
 ```
 
+## iOS App (SwiftUI)
+
+A standalone SwiftUI alarm clock lives in the `ios` directory. It schedules local notifications directly on the device and does not require the Python backend or a Raspberry Pi.
+
+1. Open the Swift files in Xcode 15 or later.
+2. Build and run the app in the iOS Simulator or on a physical device.
+3. Grant notification permission when prompted.
+
+> The Linux environment used for this repository cannot compile SwiftUI targets; no automated tests are included.
+
 ## Hardware
 
 You can purchase the GAN cube used for this project here: [GAN Smart Cube](https://amzn.to/4lgux9D).

--- a/ios/Alarm.swift
+++ b/ios/Alarm.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct Alarm: Identifiable, Codable {
+    var id: UUID
+    var date: Date
+}

--- a/ios/AlarmListView.swift
+++ b/ios/AlarmListView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct AlarmListView: View {
+    @StateObject private var viewModel = AlarmListViewModel()
+    @State private var newDate = Date()
+
+    var body: some View {
+        NavigationView {
+            VStack {
+                List {
+                    ForEach(viewModel.alarms) { alarm in
+                        Text(alarm.date, style: .time)
+                    }
+                    .onDelete(perform: viewModel.removeAlarms)
+                }
+
+                HStack {
+                    DatePicker("", selection: $newDate, displayedComponents: .hourAndMinute)
+                        .labelsHidden()
+                    Button("Add") {
+                        viewModel.addAlarm(at: newDate)
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                .padding()
+            }
+            .navigationTitle("Alarms")
+        }
+    }
+}
+
+#Preview {
+    AlarmListView()
+}

--- a/ios/AlarmListViewModel.swift
+++ b/ios/AlarmListViewModel.swift
@@ -1,0 +1,70 @@
+import Foundation
+import UserNotifications
+
+@MainActor
+class AlarmListViewModel: ObservableObject {
+    @Published var alarms: [Alarm] = []
+    private let storageKey = "alarms"
+
+    init() {
+        loadAlarms()
+        requestPermissions()
+    }
+
+    func addAlarm(at date: Date) {
+        let alarm = Alarm(id: UUID(), date: date)
+        alarms.append(alarm)
+        scheduleNotification(for: alarm)
+        saveAlarms()
+    }
+
+    func removeAlarms(at offsets: IndexSet) {
+        let removed = offsets.map { alarms[$0] }
+        alarms.remove(atOffsets: offsets)
+        for alarm in removed {
+            UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [alarm.id.uuidString])
+        }
+        saveAlarms()
+    }
+
+    private func requestPermissions() {
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { granted, error in
+            if let error = error {
+                print("Notification permission error: \(error)")
+            }
+            if !granted {
+                print("Notification permission not granted")
+            }
+        }
+    }
+
+    private func scheduleNotification(for alarm: Alarm) {
+        let content = UNMutableNotificationContent()
+        content.title = "Cube Alarm"
+        content.body = "Solve the cube to dismiss"
+        content.sound = UNNotificationSound.default
+
+        let triggerDate = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: alarm.date)
+        let trigger = UNCalendarNotificationTrigger(dateMatching: triggerDate, repeats: false)
+
+        let request = UNNotificationRequest(identifier: alarm.id.uuidString, content: content, trigger: trigger)
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error = error {
+                print("Failed to schedule notification: \(error)")
+            }
+        }
+    }
+
+    private func loadAlarms() {
+        guard let data = UserDefaults.standard.data(forKey: storageKey) else { return }
+        if let decoded = try? JSONDecoder().decode([Alarm].self, from: data) {
+            alarms = decoded
+        }
+    }
+
+    private func saveAlarms() {
+        if let data = try? JSONEncoder().encode(alarms) {
+            UserDefaults.standard.set(data, forKey: storageKey)
+        }
+    }
+}

--- a/ios/CubeAlarmApp.swift
+++ b/ios/CubeAlarmApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct CubeAlarmApp: App {
+    var body: some Scene {
+        WindowGroup {
+            AlarmListView()
+        }
+    }
+}

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,11 @@
+# Cube Alarm iOS App
+
+This directory contains a standalone SwiftUI alarm clock that schedules local notifications. No backend server or Raspberry Pi is required.
+
+To run the app:
+
+1. Open `CubeAlarmApp.swift` in Xcode 15 or later.
+2. Build and run the app in the iOS Simulator or on a device.
+3. Grant notification permission when prompted.
+
+> SwiftUI and UserNotifications are only available on Apple platforms. The Linux container used for development cannot build this target, so no automated tests are provided.


### PR DESCRIPTION
## Summary
- add standalone SwiftUI-based iOS alarm app using local notifications
- document running the iOS app without the Raspberry Pi backend

## Testing
- `swiftc ios/*.swift -o ios/app` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_688f52a800a483259d9af6a6c7a59335